### PR TITLE
Clean up, use existing fbright instead of lighten fmain

### DIFF
--- a/css/form.less
+++ b/css/form.less
@@ -143,7 +143,7 @@ select {
 label, .picker .picker-label {
   display: block;
   margin-bottom: 0;
-  color: lighten(@fmain, 20%);
+  color: @fbright;
 }
 
 legend {
@@ -207,7 +207,7 @@ legend {
 /* ---------- webform steps ----------------------------------------------- */
 .webform-progressbar {
   .f(14);
-  color: lighten(@fmain, 20%);
+  color: @fbright;
 
   // hide all but current label on small screens & small sidebar
   .webform-progressbar-page:not(.current) span {
@@ -259,7 +259,7 @@ div.webform-component-select-or-other.donation-amount {
   }
   label.option {
     .f(24);
-    color: lighten(@fmain, 25%);
+    color: lighten(@fbright, 5%);
     background-color: @background_color_light;
     border: 1px solid @background_grey_light_border;
     .rounded(8px);
@@ -298,7 +298,7 @@ div.webform-component-select-or-other.donation-amount {
       cursor: default;
       background: transparent;
       border: none;
-      color: lighten(@fmain, 20%);
+      color: @fbright;
       font-size: 100%;
       .rounded(0);
       -webkit-box-shadow: none;
@@ -328,11 +328,11 @@ div.webform-component-select-or-other.donation-amount {
       .rounded(8px);
       margin: 0 auto;
       text-align: center;
-      color: lighten(@fmain, 50%);
+      color: lighten(@fbright, 30%);
       font-weight: bold;
       &:hover, &:active, &:focus,
       &.select-or-other-checked {
-        color: lighten(@fmain, 20%);
+        color: @fbright;
         font-weight: bold;
         border: 1px solid @primary_color;
         box-shadow: 0 0 1px @primary_color inset;

--- a/js/simplicity.js
+++ b/js/simplicity.js
@@ -1,29 +1,6 @@
 (function($) {
 Drupal.behaviors.simplicity = {};
 Drupal.behaviors.simplicity.attach = function(context, settings) {
-  // scroll to top of form + padding if we are below it
-  // or if we are more than the toleratedOffset above it
-  if ('ajax' in settings) {
-    $.each(settings.ajax, function(el) {
-      var padding = 12;
-      var toleratedOffset = 50;
-      if (el && Drupal.ajax[el]) {
-        var oldsuccess = Drupal.ajax[el].success;
-
-        Drupal.ajax[el].success = function (response, status) {
-          oldsuccess.call(this, response, status);
-          var wrapperTop = $('#' + settings.ajax[el].wrapper).offset().top;
-          var diff = Math.abs(wrapperTop) - (Math.abs($('html').offset().top) || $('html')[0].scrollTop); // get scroll position across browsers
-          if (diff < 0 || Math.abs(diff) > toleratedOffset) {
-            // IE scrolls html, not body.
-            var $scrollEl = $('body')[0].scrollTop === 0 ? $('html') : $('body');
-            $scrollEl.animate({ scrollTop: (wrapperTop - padding)}, 'slow');
-          }
-        }
-      }
-    });
-  }
-
   // container id begins with webform-ajax-wrapper
   $('.webform-client-form', context).webformAjaxSlide({
     loadingDummyMsg: Drupal.t('loading'),


### PR DESCRIPTION
Theoretically no change, but it makes it easier to override the font color for child themes.